### PR TITLE
Fixed null error when icon text isn't specified

### DIFF
--- a/lib/rolling_nav_bar.dart
+++ b/lib/rolling_nav_bar.dart
@@ -584,7 +584,9 @@ class _RollingNavBarInnerState extends State<_RollingNavBarInner>
       onPressed: () {
         _setActive(indexed.index);
       },
-      textWidget: !isActive && widget.iconText.length == widget.numChildren
+      textWidget: widget.iconText != null &&
+              !isActive &&
+              widget.iconText.length == widget.numChildren
           ? widget.iconText[indexed.index]
           : null,
     );


### PR DESCRIPTION
Not specifying iconText causes null errors. Tiny fix to prevent this.