### PR TITLE
Move call to onTap callback to onPressed

### DIFF
--- a/lib/rolling_nav_bar.dart
+++ b/lib/rolling_nav_bar.dart
@@ -435,11 +435,6 @@ class _RollingNavBarInnerState extends State<_RollingNavBarInner>
   }
 
   void _setActive(int newIndex) {
-    // Invoke the optional handler for each tap event.
-    if (widget.onTap != null) {
-      widget.onTap(newIndex);
-    }
-
     if (newIndex == activeIndex) return;
 
     var _originalIndex = activeIndex;
@@ -709,6 +704,10 @@ class _RollingNavBarInnerState extends State<_RollingNavBarInner>
       maxWidth: tabChunkWidth,
       onPressed: () {
         _setActive(indexed.index);
+        // Invoke the optional handler for each tap event.
+        if (widget.onTap != null) {
+          widget.onTap(newIndex);
+        }
       },
       textWidget: widget.iconText != null &&
               !isActive &&

--- a/lib/rolling_nav_bar.dart
+++ b/lib/rolling_nav_bar.dart
@@ -706,7 +706,7 @@ class _RollingNavBarInnerState extends State<_RollingNavBarInner>
         _setActive(indexed.index);
         // Invoke the optional handler for each tap event.
         if (widget.onTap != null) {
-          widget.onTap(newIndex);
+          widget.onTap(indexed.index);
         }
       },
       textWidget: widget.iconText != null &&


### PR DESCRIPTION
Thanks for this package!

I believe there's a small bug: the call to the `widget.onTap` callback should be in `onPressed` rather than in `_setActive`, since `_setActive` is also called from `didUpdateWidget`, which I don't think should call the `onTap` callback. (This leads to problems when `onTap` calls `setState`, for example, which then gets triggered during a rebuild.)

Hopefully this PR handles it all correctly.